### PR TITLE
NewConfig instead of DefaultConfig

### DIFF
--- a/src/dome9/client/client.go
+++ b/src/dome9/client/client.go
@@ -16,7 +16,7 @@ type Client struct {
 // NewClient returns a new client for the specified apiKey.
 func NewClient(config *dome9.Config) (c *Client) {
 	if config == nil {
-		config = dome9.DefaultConfig()
+		config, _ = dome9.NewConfig("", "", "")
 	}
 	c = &Client{Config: config}
 	return


### PR DESCRIPTION
- Config Instance is now returned with new 
- No need to set any creds / url 
- Argument access and secret if zero value it will use env params 
- Argument baseURL is set either to default url or value 