### PR TITLE
Fix region name in cloud account AWS request struct

### DIFF
--- a/services/cloudaccounts/aws/aws.go
+++ b/services/cloudaccounts/aws/aws.go
@@ -59,7 +59,7 @@ type CloudAccountResponse struct {
 	} `json:"iamSafe,omitempty"`
 	NetSec struct {
 		Regions []struct {
-			Region           string `json:"awsRegion"`
+			Region           string `json:"region"`
 			Name             string `json:"name"`
 			Hidden           bool   `json:"hidden"`
 			NewGroupBehavior string `json:"newGroupBehavior"`


### PR DESCRIPTION
Previously it didn't work since the name in the actual server isn't "awsRegion" but "region"