### PR TITLE
fix: Add a missing `vendor` field to Azure cloud account creation request

### DIFF
--- a/services/cloudaccounts/azure/azure.go
+++ b/services/cloudaccounts/azure/azure.go
@@ -10,6 +10,7 @@ import (
 
 type CloudAccountRequest struct {
 	Name                   string                  `json:"name,omitempty"`
+	Vendor                 string                  `json:"vendor,omitempty"`
 	SubscriptionID         string                  `json:"subscriptionId,omitempty"`
 	TenantID               string                  `json:"tenantId,omitempty"`
 	Credentials            CloudAccountCredentials `json:"credentials,omitempty"`


### PR DESCRIPTION
I tried using this library to create a cloud account in Azure Gov in Dome9, but failed. Seems like in order to do that you need to set the `vendor` field to `azuregov`. I tested this on my staging environment, and everything worked as expected with these changes.

See https://api-v2-docs.dome9.com/#schemadome9-web-api-models-azurecloudaccountviewmodel for API docs details on this parameter.

Also, I'd appreciate maintainers cutting a release with these changes once they are merged.